### PR TITLE
Add S3 metrics

### DIFF
--- a/cloudwatch_template.xml
+++ b/cloudwatch_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.0</version>
-    <date>2017-04-12T21:56:24Z</date>
+    <date>2017-09-27T19:59:39Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -32,6 +32,9 @@
                 </application>
                 <application>
                     <name>RDS Storage</name>
+                </application>
+                <application>
+                    <name>S3</name>
                 </application>
                 <application>
                     <name>System health</name>
@@ -853,6 +856,210 @@
                                     <item>
                                         <host>Cloudwatch Template</host>
                                         <key>cloudwatch.metric[600,FreeStorageSpace,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                    <host_prototypes/>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>S3 discovery</name>
+                    <type>10</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>aws.discovery[s3,{$REGION},{$ACCOUNT}]</key>
+                    <delay>3600</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>0</lifetime>
+                    <description/>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>{#BUCKET_NAME} Bucket Size</name>
+                            <type>10</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>cloudwatch.metric[600,BucketSizeBytes,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=StandardStorage&quot;,{$ACCOUNT}]</key>
+                            <delay>600</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>Bytes</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>S3</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#BUCKET_NAME} Number Of Objects</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>cloudwatch.metric[600,NumberOfObjects,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=AllStorageTypes&quot;,{$ACCOUNT}]</key>
+                            <delay>600</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>Objects</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>S3</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>{Cloudwatch Template:cloudwatch.metric[600,BucketSizeBytes,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=StandardStorage&quot;,{$ACCOUNT}].last()}=-1 or&#13;
+{Cloudwatch Template:cloudwatch.metric[600,NumberOfObjects,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=AllStorageTypes&quot;,{$ACCOUNT}].last()}=-1</expression>
+                            <name>S3: {#BUCKET_NAME} has no datapoints</name>
+                            <url/>
+                            <status>0</status>
+                            <priority>1</priority>
+                            <description>1. Your item is incorrectly configured (dimension, namespace, metric name could be wrong)&#13;
+2. Instance was terminated and this item will disappear after next discovery</description>
+                            <type>0</type>
+                            <dependencies/>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>{#BUCKET_NAME} Bucket Size</name>
+                            <width>900</width>
+                            <height>200</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>0</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>2</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Cloudwatch Template</host>
+                                        <key>cloudwatch.metric[600,BucketSizeBytes,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=StandardStorage&quot;,{$ACCOUNT}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                        <graph_prototype>
+                            <name>{#BUCKET_NAME} Number of Objects</name>
+                            <width>900</width>
+                            <height>200</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>0</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>2</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Cloudwatch Template</host>
+                                        <key>cloudwatch.metric[600,NumberOfObjects,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=AllStorageTypes&quot;,{$ACCOUNT}]</key>
                                     </item>
                                 </graph_item>
                             </graph_items>

--- a/cloudwatch_template.xml
+++ b/cloudwatch_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.0</version>
-    <date>2017-09-27T19:59:39Z</date>
+    <date>2017-09-27T20:42:46Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -942,7 +942,7 @@
                         </item_prototype>
                         <item_prototype>
                             <name>{#BUCKET_NAME} Number Of Objects</name>
-                            <type>0</type>
+                            <type>10</type>
                             <snmp_community/>
                             <multiplier>0</multiplier>
                             <snmp_oid/>

--- a/zabbix-scripts/scripts/cloudwatch.metric
+++ b/zabbix-scripts/scripts/cloudwatch.metric
@@ -6,18 +6,18 @@ import argparse
 
 
 class Checker(AWSClient):
-    def get_metric(self, interval, metric, namespace, statistic, dimension):
+    def get_metric(self, interval, metric, namespace, statistic, dimensions):
         # Constructing timestamps for limiting CloudWatch datapoint list
         end_time = datetime.datetime.utcnow()
         start_time = end_time - datetime.timedelta(seconds=interval)
         result = self.client.get_metric_statistics(
-                Namespace=namespace,
-                MetricName=metric,
-                Dimensions=[dimension, ],
-                StartTime=start_time.isoformat(),
-                EndTime=end_time.isoformat(),
-                Statistics=[statistic, ],
-                Period=interval)
+            Namespace=namespace,
+            MetricName=metric,
+            Dimensions=dimensions,
+            StartTime=start_time.isoformat(),
+            EndTime=end_time.isoformat(),
+            Statistics=[statistic, ],
+            Period=interval)
         # We use only the first datapoint from list
         # Return -1 if there are no datapoints
         if len(result["Datapoints"]) > 0:
@@ -57,7 +57,7 @@ if __name__ == "__main__":
                         help="Type of statistic",
                         required=True)
     parser.add_argument("--dimension", dest="dimension",
-                        help="Dimension (instance id)",
+                        help="Dimension(s)",
                         required=True)
     parser.add_argument("--region", dest="region",
                         help="Instance region",
@@ -75,8 +75,10 @@ if __name__ == "__main__":
 
     # AWS requires dimension to be dict like:
     # { "Name": dimension_name, "Value" dimension_value }
-    instance = args.dimension.split("=")
-    dimension = dict(zip(("Name", "Value"), instance))
+    dimensions = list()
+    for dimension in args.dimension.split(","):
+        instance = dimension.split("=")
+        dimensions.append(dict(zip(("Name", "Value"), instance)))
 
     default_path = "/usr/lib/zabbix/scripts/conf/aws.conf"
     conf_file = args.config if args.config else default_path
@@ -89,4 +91,4 @@ if __name__ == "__main__":
                              metric=args.metric,
                              namespace=args.namespace,
                              statistic=args.statistic,
-                             dimension=dimension)
+                             dimensions=dimensions)

--- a/zabbix-scripts/scripts/discovery/s3.py
+++ b/zabbix-scripts/scripts/discovery/s3.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+from basic_discovery import BasicDiscoverer
+
+
+class Discoverer(BasicDiscoverer):
+    def discovery(self, *args):
+        response = self.client.list_buckets()
+        data = list()
+        for bucket in response["Buckets"]:
+            ldd = {
+                "{#NAME}": bucket['Name'],
+            }
+            data.append(ldd)
+        return data

--- a/zabbix-scripts/scripts/discovery/s3.py
+++ b/zabbix-scripts/scripts/discovery/s3.py
@@ -8,7 +8,7 @@ class Discoverer(BasicDiscoverer):
         data = list()
         for bucket in response["Buckets"]:
             ldd = {
-                "{#NAME}": bucket['Name'],
+                "{#BUCKET_NAME}": bucket['Name'],
             }
             data.append(ldd)
         return data


### PR DESCRIPTION
Added:
- S3 discovery object
- Allow cloudwatch.metrics to be passed multiple dimensions (required for many Cloudwatch metrics)
- Add S3 application, discovery, items, triggers and graphs to template