### PR TITLE
Discovery should default to empty list if it failed

### DIFF
--- a/zabbix-scripts/scripts/discovery/basic_discovery.py
+++ b/zabbix-scripts/scripts/discovery/basic_discovery.py
@@ -6,8 +6,12 @@ import json
 class BasicDiscoverer(AWSClient):
     def get_instances(self, *args):
         "Runs discovery method and packs result into JSON"
-        data = self.discovery(*args)
-        return json.dumps({"data": data})
+
+        try:
+            data = self.discovery(*args)
+            return json.dumps({"data": data})
+        except:
+            return json.dumps({"data": []})
 
     def discovery(self, *args):
         "Method that should be overriden inside inherited classes"


### PR DESCRIPTION
This changes the BasicDiscoverer class to catch errors and return a valid LLD JSON with an empty list if discovery failed for any reason.
