### PR TITLE
Support for Application Load Balancers (elbv2)

### DIFF
--- a/cloudwatch_template.xml
+++ b/cloudwatch_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>3.0</version>
-    <date>2017-09-27T20:42:46Z</date>
+    <version>3.4</version>
+    <date>2018-08-28T04:37:07Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -23,6 +23,9 @@
                 </application>
                 <application>
                     <name>ELB</name>
+                </application>
+                <application>
+                    <name>ELBv2</name>
                 </application>
                 <application>
                     <name>EMR</name>
@@ -58,7 +61,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -79,17 +81,15 @@
                             <name>CPU Usage {#NAME}</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,CPUUtilization,AWS/EC2,Average,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>%</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -97,11 +97,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -117,23 +114,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Instance health {#NAME}</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,StatusCheckFailed_Instance,AWS/EC2,Maximum,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}]</key>
                             <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>fail(s)</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -141,11 +139,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -161,23 +156,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Hypervisor health {#NAME}</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,StatusCheckFailed_System,AWS/EC2,Maximum,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>fail(s)</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -185,11 +181,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -205,69 +198,104 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,StatusCheckFailed_System,AWS/EC2,Maximum,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].last()}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EC2: Hypervisor fail on {#NAME}</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>5</priority>
                             <description/>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,StatusCheckFailed_Instance,AWS/EC2,Maximum,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].min(#3)}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EC2: Instance fail on {#NAME}</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
                             <description/>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,CPUUtilization,AWS/EC2,Average,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].last()}=-1 or {Cloudwatch Template:cloudwatch.metric[600,StatusCheckFailed_System,AWS/EC2,Maximum,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].last()}=-1 or {Cloudwatch Template:cloudwatch.metric[600,StatusCheckFailed_Instance,AWS/EC2,Maximum,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].last()}=-1</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EC2: No datapoints for {#NAME}</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
                             <description>1. Your item is incorrectly configured (dimension, namespace, metric name could be wrong)&#13;
-2. Instance was terminated and this item will disappear after next discovery</description>
+                                2. Instance was terminated and this item will disappear after next discovery</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,CPUUtilization,AWS/EC2,Average,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].last()}&gt;80</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EC2: {#NAME}: High CPU usage</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies>
                                 <dependency>
                                     <name>EC2: {#NAME}: High CPU usage for last 60 min</name>
                                     <expression>{Cloudwatch Template:cloudwatch.metric[600,CPUUtilization,AWS/EC2,Average,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].avg(60m)}&gt;80</expression>
+                                    <recovery_expression/>
                                 </dependency>
                             </dependencies>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,CPUUtilization,AWS/EC2,Average,{$REGION},InstanceId={#INSTANCE_ID},{$ACCOUNT}].avg(60m)}&gt;80</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EC2: {#NAME}: High CPU usage for last 60 min</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes/>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
                     <name>ELB Discovery</name>
@@ -285,7 +313,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -306,17 +333,15 @@
                             <name>{#BALANCER_NAME} UnHealthyHostCount</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,UnHealthyHostCount,AWS/ELB,Maximum,{$REGION},LoadBalancerName={#BALANCER_NAME},{$ACCOUNT}]</key>
                             <delay>300</delay>
-                            <history>30</history>
-                            <trends>60</trends>
+                            <history>30d</history>
+                            <trends>60d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>hosts</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -324,11 +349,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -344,23 +366,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#BALANCER_NAME} active instances</name>
                             <type>15</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>instances[{#BALANCER_NAME}]</key>
                             <delay>1800</delay>
-                            <history>30</history>
-                            <trends>60</trends>
+                            <history>30d</history>
+                            <trends>60d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -368,11 +391,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params>{#INSTANCES_COUNT}</params>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -388,33 +408,256 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:instances[{#BALANCER_NAME}].last()}=0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>ELB: {#BALANCER_NAME} has no active instances</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
                             <description>This might be due to degraded instances or balancer being inactive.</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,UnHealthyHostCount,AWS/ELB,Maximum,{$REGION},LoadBalancerName={#BALANCER_NAME},{$ACCOUNT}].min(#3)}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>ELB: {#BALANCER_NAME} unhealthy nodes</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes/>
                     <host_prototypes/>
+                    <jmx_endpoint/>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>ELBv2 Discovery</name>
+                    <type>10</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>aws.discovery[elbv2,{$REGION},{$ACCOUNT}]</key>
+                    <delay>3600</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>0</lifetime>
+                    <description>AWS Application Load Balancer (or ELB v2) discovery rules.&#13;
+                        &#13;
+                        https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} {#TARGET_GROUP_NAME} UnHealthyHostCount</name>
+                            <type>10</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>cloudwatch.metric[120,UnHealthyHostCount,AWS/ApplicationELB,Maximum,{$REGION},&quot;LoadBalancer={#TARGET_GROUP_LOAD_BALANCER_ARN},TargetGroup={#TARGET_GROUP_ARN}&quot;,{$ACCOUNT}]</key>
+                            <delay>120</delay>
+                            <history>30d</history>
+                            <trends>60d</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>hosts</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>ELBv2</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <application_prototypes/>
+                            <master_item_prototype/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} target group {#TARGET_GROUP_NAME} total targets</name>
+                            <type>15</type>
+                            <snmp_community/>
+                            <snmp_oid/>
+                            <key>instances[{#TARGET_GROUP_LOAD_BALANCER_NAME}][{#TARGET_GROUP_NAME}]</key>
+                            <delay>3600</delay>
+                            <history>30d</history>
+                            <trends>60d</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params>{#TARGET_COUNT}</params>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>ELBv2</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <application_prototypes/>
+                            <master_item_prototype/>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>{Cloudwatch Template:instances[{#TARGET_GROUP_LOAD_BALANCER_NAME}][{#TARGET_GROUP_NAME}].last()}=-1</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
+                            <name>ELBv2: No data points for {#TARGET_GROUP_LOAD_BALANCER_NAME} target {#TARGET_GROUP_NAME}</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
+                            <url/>
+                            <status>0</status>
+                            <priority>1</priority>
+                            <description>1. Your item is incorrectly configured (dimension, namespace, metric name could be wrong)&#13;
+                                2. Instance was terminated and this item will disappear after next discovery</description>
+                            <type>0</type>
+                            <manual_close>0</manual_close>
+                            <dependencies/>
+                            <tags/>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>{Cloudwatch Template:instances[{#TARGET_GROUP_LOAD_BALANCER_NAME}][{#TARGET_GROUP_NAME}].last()}=0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
+                            <name>ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} target group {#TARGET_GROUP_NAME} has no active instances</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
+                            <url/>
+                            <status>0</status>
+                            <priority>1</priority>
+                            <description/>
+                            <type>0</type>
+                            <manual_close>0</manual_close>
+                            <dependencies/>
+                            <tags/>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>{Cloudwatch Template:cloudwatch.metric[120,UnHealthyHostCount,AWS/ApplicationELB,Maximum,{$REGION},&quot;LoadBalancer={#TARGET_GROUP_LOAD_BALANCER_ARN},TargetGroup={#TARGET_GROUP_ARN}&quot;,{$ACCOUNT}].last()}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
+                            <name>ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} target group {#TARGET_GROUP_NAME} unhealthy nodes</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
+                            <url/>
+                            <status>0</status>
+                            <priority>4</priority>
+                            <description/>
+                            <type>0</type>
+                            <manual_close>0</manual_close>
+                            <dependencies/>
+                            <tags/>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>ELBv2 {#TARGET_GROUP_LOAD_BALANCER_NAME} {#TARGET_GROUP_NAME} UnHealthyHostCount</name>
+                            <width>900</width>
+                            <height>200</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>0</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>2</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Cloudwatch Template</host>
+                                        <key>cloudwatch.metric[120,UnHealthyHostCount,AWS/ApplicationELB,Maximum,{$REGION},&quot;LoadBalancer={#TARGET_GROUP_LOAD_BALANCER_ARN},TargetGroup={#TARGET_GROUP_ARN}&quot;,{$ACCOUNT}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                    <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
                     <name>EMR discovery</name>
@@ -432,7 +675,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -453,17 +695,15 @@
                             <name>{#CLUSTER_NAME} failed apps</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,AppsFailed,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}]</key>
                             <delay>300</delay>
-                            <history>30</history>
-                            <trends>365</trends>
+                            <history>30d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>app(s)</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -471,11 +711,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -491,23 +728,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#CLUSTER_NAME} HDFS utilization</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,HDFSUtilization,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}]</key>
                             <delay>300</delay>
-                            <history>30</history>
-                            <trends>365</trends>
+                            <history>30d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>%</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -515,11 +753,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -535,23 +770,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#CLUSTER_NAME} unhealthy nodes</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,MRUnhealthyNodes,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}]</key>
                             <delay>300</delay>
-                            <history>30</history>
-                            <trends>365</trends>
+                            <history>30d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>node(s)</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -559,11 +795,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -579,54 +812,82 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,MRUnhealthyNodes,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].last()}&gt;0</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EMR: Unhealthy nodes in {#CLUSTER_NAME}</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>5</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>(({TRIGGER.VALUE}=0 and {Cloudwatch Template:cloudwatch.metric[600,AppsFailed,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].last()}&gt;0 and {Cloudwatch Template:cloudwatch.metric[600,AppsFailed,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].change()}&gt;0) or ({TRIGGER.VALUE}=1 and {Cloudwatch Template:cloudwatch.metric[600,AppsFailed,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].delta(#4)}&gt;0))</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EMR: {#CLUSTER_NAME} has new failed YARN apps</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,HDFSUtilization,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].last()}=-1 or {Cloudwatch Template:cloudwatch.metric[600,MRUnhealthyNodes,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].last()}=-1</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EMR: {#CLUSTER_NAME} has no datapoints</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
                             <description>1. Your item is incorrectly configured (dimension, namespace, metric name could be wrong)&#13;
-2. Instance was terminated and this item will disappear after next discovery</description>
+                                2. Instance was terminated and this item will disappear after next discovery</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,HDFSUtilization,AWS/ElasticMapReduce,Average,{$REGION},JobFlowId={#CLUSTER_ID},{$ACCOUNT}].avg(#2)}&gt;80</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>EMR: {#CLUSTER_NAME} high HDFS usage</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes/>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
                     <name>RDS discovery</name>
@@ -634,7 +895,7 @@
                     <snmp_community/>
                     <snmp_oid/>
                     <key>aws.discovery[rds,{$REGION},{$ACCOUNT}]</key>
-                    <delay>3600</delay>
+                    <delay>3600;3600/1-5,00:00-24:00;21600/6-7,00:00-24:00</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -644,7 +905,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex>3600/1-5,00:00-24:00;21600/6-7,00:00-24:00</delay_flex>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -665,17 +925,15 @@
                             <name>{#RDS_ID} CPU usage</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,CPUUtilization,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>%</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -683,11 +941,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -703,23 +958,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#RDS_ID} free storage space</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,FreeStorageSpace,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -727,11 +983,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -747,23 +1000,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#RDS_ID} % free storage space</name>
                             <type>15</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>freepercent[{#RDS_ID}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>%</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -771,11 +1025,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params>last(&quot;cloudwatch.metric[600,FreeStorageSpace,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}]&quot;)/({#STORAGE}/100)</params>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -791,40 +1042,61 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,CPUUtilization,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}].last()}=-1 or {Cloudwatch Template:cloudwatch.metric[600,FreeStorageSpace,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}].last()}=-1</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>RDS: {#RDS_ID} has no datapoints</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
                             <description>1. Your item is incorrectly configured (dimension, namespace, metric name could be wrong)&#13;
-2. Instance was terminated and this item will disappear after next discovery</description>
+                                2. Instance was terminated and this item will disappear after next discovery</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,CPUUtilization,AWS/RDS,Average,{$REGION},DBInstanceIdentifier={#RDS_ID},{$ACCOUNT}].avg(#2)}&gt;80</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>RDS: {#RDS_ID} high CPU usage</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
                             <description>{ITEM.VALUE}</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:freepercent[{#RDS_ID}].last()}&lt;20</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>RDS: {#RDS_ID} low on space</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
                             <description>{ITEM.VALUE} left</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes>
@@ -862,6 +1134,7 @@
                         </graph_prototype>
                     </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
                     <name>S3 discovery</name>
@@ -879,7 +1152,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -900,17 +1172,15 @@
                             <name>{#BUCKET_NAME} Bucket Size</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,BucketSizeBytes,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=StandardStorage&quot;,{$ACCOUNT}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>Bytes</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -918,11 +1188,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -938,23 +1205,24 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#BUCKET_NAME} Number Of Objects</name>
                             <type>10</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cloudwatch.metric[600,NumberOfObjects,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=AllStorageTypes&quot;,{$ACCOUNT}]</key>
                             <delay>600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
+                            <history>90d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>Objects</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -962,11 +1230,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -982,21 +1247,30 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Cloudwatch Template:cloudwatch.metric[600,BucketSizeBytes,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=StandardStorage&quot;,{$ACCOUNT}].last()}=-1 or&#13;
-{Cloudwatch Template:cloudwatch.metric[600,NumberOfObjects,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=AllStorageTypes&quot;,{$ACCOUNT}].last()}=-1</expression>
+                                {Cloudwatch Template:cloudwatch.metric[600,NumberOfObjects,AWS/S3,Average,{$REGION},&quot;BucketName={#BUCKET_NAME},StorageType=AllStorageTypes&quot;,{$ACCOUNT}].last()}=-1</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>S3: {#BUCKET_NAME} has no datapoints</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
                             <description>1. Your item is incorrectly configured (dimension, namespace, metric name could be wrong)&#13;
-2. Instance was terminated and this item will disappear after next discovery</description>
+                                2. Instance was terminated and this item will disappear after next discovery</description>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes>
@@ -1066,8 +1340,10 @@
                         </graph_prototype>
                     </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
             </discovery_rules>
+            <httptests/>
             <macros>
                 <macro>
                     <macro>{$ACCOUNT}</macro>

--- a/zabbix-scripts/scripts/discovery/elbv2.py
+++ b/zabbix-scripts/scripts/discovery/elbv2.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+from basic_discovery import BasicDiscoverer
+
+import re
+
+class Discoverer(BasicDiscoverer):
+    def discovery(self, *args):
+
+        response = self.client.describe_target_groups()
+
+        data = []
+
+        # Load balancer data cache
+        LoadBalancersDescrByArn = {}
+
+        for TargetGroup in response["TargetGroups"]:
+
+            # A target group may be related to one or more load balancers - create one entry per lb-target group
+            # combination
+            for LoadBalancerArn in TargetGroup["LoadBalancerArns"]:
+
+                if LoadBalancerArn not in LoadBalancersDescrByArn:
+                    LoadBalancersDescrByArn[LoadBalancerArn] = self.client.describe_load_balancers(
+                        LoadBalancerArns=[LoadBalancerArn]
+                    )['LoadBalancers'][0]
+
+                target_health = self.client.describe_target_health(
+                    TargetGroupArn=TargetGroup["TargetGroupArn"]
+                )
+
+                # Get the short ARNs that are effectivelly used when querying for metrics
+                Arn = re.search(":(targetgroup/.*)", TargetGroup["TargetGroupArn"]).group(1)
+                LoadBalancerShortArn = re.search(":loadbalancer/(.*)", LoadBalancerArn).group(1)
+
+                # Final discovery entry
+                ldd = {
+                    "{#TARGET_GROUP_NAME}": TargetGroup["TargetGroupName"],
+                    "{#TARGET_GROUP_ARN}": Arn,
+                    "{#TARGET_GROUP_PORT}": TargetGroup["Port"],
+                    "{#TARGET_GROUP_VPC_ID}": TargetGroup["VpcId"],
+                    "{#TARGET_GROUP_LOAD_BALANCER_NAME}": LoadBalancersDescrByArn[LoadBalancerArn]['LoadBalancerName'],
+                    "{#TARGET_GROUP_LOAD_BALANCER_DNS_NAME}": LoadBalancersDescrByArn[LoadBalancerArn]['DNSName'],
+                    "{#TARGET_GROUP_LOAD_BALANCER_ARN}": LoadBalancerShortArn,
+                    "{#TARGET_COUNT}": len(target_health['TargetHealthDescriptions']),
+                }
+
+                # Next load balancer in target group
+                data.append(ldd)
+
+        return data


### PR DESCRIPTION

This PR adds basic support for monitoring Application Load Balancers (ALB or ELBv2) as requested by issue #5 

Hi, 

First of all thank you for sharing your work with the community. Your Zabbix scripts were very useful today to me to get everything up and running quickly. I needed also the ALB support so I added a new discovery class. I'm not a Python developer: feel free to ask for any style changes or a different approach if necessary.

An application load balancer has one or more "Target groups" and each target group has one or more targets. 

AWS docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html

**Note:** The Zabbix template is from Zabbix v3.4 (I  #don't have a Zabbix 3.0 instance available to add the new items without changing the version)

**New Application:** ELBv2

**Discovery for each target in the application load balancer:**

1. {#TARGET_GROUP_LOAD_BALANCER_NAME}
2. {#TARGET_GROUP_PORT}
3. {#TARGET_GROUP_LOAD_BALANCER_ARN}
4. {#TARGET_GROUP_VPC_ID}
5. {#TARGET_GROUP_LOAD_BALANCER_DNS_NAME}
6. {#TARGET_GROUP_ARN}
7. {#TARGET_GROUP_NAME}
8. {#TARGET_COUNT}
    
**Item prototypes:**
	
1.  ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} target group {#TARGET_GROUP_NAME} total targets
    - Calculated: instances[{#TARGET_GROUP_LOAD_BALANCER_NAME}][{#TARGET_GROUP_NAME}]    
2.  ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} {#TARGET_GROUP_NAME} UnHealthyHostCount (Formula: {#TARGET_COUNT})
    - External check: cloudwatch.metric[120,UnHealthyHostCount,AWS/ApplicationELB,Maximum,{$REGION},"LoadBalancer={#TARGET_GROUP_LOAD_BALANCER_ARN},TargetGroup={#TARGET_GROUP_ARN}",{$ACCOUNT}]

**Trigger prototypes:**

1. ELBv2: No data points for {#TARGET_GROUP_LOAD_BALANCER_NAME} target {#TARGET_GROUP_NAME}
2. ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} target group {#TARGET_GROUP_NAME} has no active instances
3. ELBv2: {#TARGET_GROUP_LOAD_BALANCER_NAME} target group {#TARGET_GROUP_NAME} unhealthy nodes

**Sample discovery output:**
```
./aws_discovery.py --service elbv2 --region us-west-2 --account zabbix
```

```
{
  "data": [
    {
      "{#TARGET_GROUP_LOAD_BALANCER_NAME}": "my-alb",
      "{#TARGET_GROUP_PORT}": 80,
      "{#TARGET_GROUP_LOAD_BALANCER_ARN}": "app/my-alb/b44d85146ca026e4",
      "{#TARGET_GROUP_VPC_ID}": "vpc-2f63274a",
      "{#TARGET_GROUP_LOAD_BALANCER_DNS_NAME}": "my-alb-1547203952.us-west-2.elb.amazonaws.com",
      "{#TARGET_GROUP_ARN}": "targetgroup/my_target_group/991198ea77cd3df1",
      "{#TARGET_GROUP_NAME}": "my_target_group",
      "{#TARGET_COUNT}": 2
    }
  ]
}
```

Example of an item generated by one of the discovery item protoype's:

```
cloudwatch.metric[120,UnHealthyHostCount,AWS/ApplicationELB,Maximum,{$REGION},"LoadBalancer=app/my-alb/b44d85146ca026e4,TargetGroup=my_target_group/my-alb-cluster01/124f7add7d583f11",{$ACCOUNT}]
```

Which would result in the following being executed:

```
./cloudwatch.metric --interval 120 --metric UnHealthyHostCount --namespace AWS/ApplicationELB --statistic Maximum --region us-west-2 --dimension "LoadBalancer=app/my-alb/b44d85146ca026e4,TargetGroup=targetgroup/`my_target_group/991198ea77cd3df1" --account zabbix
```