### PR TITLE
S3 discovery: return only those buckets that belong to the active region

### DIFF
--- a/zabbix-scripts/scripts/discovery/aws_client.py
+++ b/zabbix-scripts/scripts/discovery/aws_client.py
@@ -13,3 +13,4 @@ class AWSClient(object):
             aws_access_key_id=aws_key,
             aws_secret_access_key=aws_secret,
             region_name=region)
+        self.region = region

--- a/zabbix-scripts/scripts/discovery/s3.py
+++ b/zabbix-scripts/scripts/discovery/s3.py
@@ -4,11 +4,19 @@ from basic_discovery import BasicDiscoverer
 
 class Discoverer(BasicDiscoverer):
     def discovery(self, *args):
+
         response = self.client.list_buckets()
         data = list()
-        for bucket in response["Buckets"]:
+
+        # list_buckets() will return the buckets in all regions. Get only those in the requested region
+        # See https://stackoverflow.com/questions/49814173/boto3-get-only-s3-buckets-of-specific-region
+        region_buckets = \
+            [bucket["Name"] for bucket in self.client.list_buckets()["Buckets"] \
+            if self.client.get_bucket_location(Bucket=bucket['Name'])['LocationConstraint'] == self.region]
+
+        for bucket_name in region_buckets:
             ldd = {
-                "{#BUCKET_NAME}": bucket['Name'],
+                "{#BUCKET_NAME}": bucket_name,
             }
             data.append(ldd)
         return data


### PR DESCRIPTION
Currently S3 discovery returns the buckets in all regions, regardless of the region specified to the discovery script. The problem comes when trying to create metrics for those buckets because the metrics are tied to the region of the bucket, so some of the created items from the prototypes will always return empty datapoints.

This PR filters the discovered buckets to those only in the active region, making all the metrics valid for all the buckets discovered once the items have been created from their protoypes.
