### PR TITLE
This method will be removed in future versions

### DIFF
--- a/zabbix-scripts/scripts/aws_discovery.py
+++ b/zabbix-scripts/scripts/aws_discovery.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-import ConfigParser
+#!/usr/bin/python3
+import configparser
 import argparse
 import importlib
 
@@ -30,8 +30,8 @@ if __name__ == "__main__":
     # Config contains credentials for specified accounts (see sample config)
     default_path = "/usr/lib/zabbix/scripts/conf/aws.conf"
     conf_file = args.config if args.config else default_path
-    config = ConfigParser.ConfigParser()
-    config.readfp(open(conf_file))
+    config = configparser.ConfigParser()
+    config.read_file(open(conf_file))
 
     # Tricky part is to dynamically import ONLY one module
     # for the serice that was requested by CLI argument
@@ -41,4 +41,4 @@ if __name__ == "__main__":
     # Create instance of discoverer from this module and run actual discovery
     d = discovery_module.Discoverer(config, args.account,
                                     args.service, args.region)
-    print d.get_instances(*args.args)
+    print (d.get_instances(*args.args))


### PR DESCRIPTION
Proposed fix for python 3: This method will be removed in future versions. Use 'parser.read_file()' instead